### PR TITLE
fixes #7 - Formula for objconv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,4 @@ script:
   # Install packages
   - brew install gcc-arm-none-eabi-63
   - brew install skycoin-cx
+  - brew install objconv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Formula for installing [CX](https://github.com/skycoin/cx)
+- Formula for installing `gcc-arm-none-eabi` needed for [Skycoin hardware wallet](https://github.com/skycoin/hardware-wallet)
+- Formula for installing agner's [objconv](https://www.agner.org/optimize/#objconv) needed for Travis builds of [Skycoin hardware wallet](https://github.com/skycoin/hardware-wallet)
+
+### Fixed
+
+### Changed
+
+### Removed
+

--- a/Formula/objconv.rb
+++ b/Formula/objconv.rb
@@ -6,7 +6,7 @@ class Objconv < Formula
   homepage "https://www.agner.org/optimize/#objconv"
   url "https://www.agner.org/optimize/objconv.zip"
   version "2.49"
-  sha256 "f2c0c4cd6ff227e76ffed5796953cd9ae9eb228847ca9a14dba6392c573bb7a4"
+  sha256 "dab11f4c63ef06ebfd5038a5e8d42e336d5aff11c6143bad252e84b953a3e672"
   def install
     system "unzip", "source.zip",
                     "-dsrc"

--- a/Formula/objconv.rb
+++ b/Formula/objconv.rb
@@ -1,0 +1,26 @@
+
+# Initial import from https://github.com/hawkw/homebrew-grub/blob/54010f6/Formula/objconv.rb
+
+class Objconv < Formula
+  desc "Object file converter and disassembler"
+  homepage "https://www.agner.org/optimize/#objconv"
+  url "https://www.agner.org/optimize/objconv.zip"
+  version "2.49"
+  sha256 "f2c0c4cd6ff227e76ffed5796953cd9ae9eb228847ca9a14dba6392c573bb7a4"
+  def install
+    system "unzip", "source.zip",
+                    "-dsrc"
+    # objconv doesn't have a Makefile, so we have to call
+    # the C++ compiler ourselves
+    system ENV.cxx, "-o", "objconv",
+                    "-O2",
+                    *Dir["src/*.cpp"],
+                    "--prefix=#{prefix}"
+    bin.install "objconv"
+  end
+
+  test do
+    system "#{bin}/objconv", "-h"
+    # TODO: write better tests
+  end
+end

--- a/Formula/objconv.rb
+++ b/Formula/objconv.rb
@@ -1,4 +1,3 @@
-
 # Initial import from https://github.com/hawkw/homebrew-grub/blob/54010f6/Formula/objconv.rb
 
 class Objconv < Formula


### PR DESCRIPTION
Fixes #7 

Changes:
- Import formula from https://github.com/hawkw/homebrew-grub/blob/54010f6/Formula/objconv.rb
- Travis tests

Needs to be mentioned in CHANGELOG:
yes