### PR TITLE
[gcc-arm] fixes #11 - GCC ARM 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
   - brew style $(brew --repo $TRAVIS_REPO_SLUG)/Formula/*.rb
 
   # Install packages
+  - brew install gcc-arm-none-eabi-53
   - brew install gcc-arm-none-eabi-63
   - brew install skycoin-cx
   - brew install objconv

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ script:
 
   # Install packages
   - brew install gcc-arm-none-eabi-53
+  - brew unlink gcc-arm-none-eabi-53
   - brew install gcc-arm-none-eabi-63
+  - brew unlink gcc-arm-none-eabi-63
   - brew install skycoin-cx
+  - brew unlink skycoin-cx
   - brew install objconv
+  - brew unlink objconv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Formula for installing [CX](https://github.com/skycoin/cx)
-- Formula for installing `gcc-arm-none-eabi` needed for [Skycoin hardware wallet](https://github.com/skycoin/hardware-wallet)
+- Formula for installing `gcc-arm-none-eabi` needed for
+  * [Skycoin hardware wallet](https://github.com/skycoin/hardware-wallet)
+  * [Skycoin Ledger Nano S](https://github.com/skycoin/ledger-nano)
 - Formula for installing agner's [objconv](https://www.agner.org/optimize/#objconv) needed for Travis builds of [Skycoin hardware wallet](https://github.com/skycoin/hardware-wallet)
 
 ### Fixed

--- a/Formula/gcc-arm-none-eabi-53.rb
+++ b/Formula/gcc-arm-none-eabi-53.rb
@@ -1,0 +1,15 @@
+require "formula"
+
+class GccArmNoneEabi53 < Formula
+  desc "GNU Embedded Toolchain for ARM"
+  homepage "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads"
+  url "https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/gcc-arm-none-eabi-5_3-2016q1-20160330-mac.tar.bz2"
+  version "20160330"
+  # url 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/5_3-2016q1/gccarmnoneeabi532016q120160330mactar.bz2?revision=f8c9bfa2-ae89-470c-a845-5fa423439b47?product=GNU-RM%20Downloads,64-bit,,Mac%20OS%20X,5-2016-q1-update'
+  sha256 "5656cdec40f99d5c054a85bbc694276e1c4a1488cdacbbc448bc6acd3bbe070d"
+
+  def install
+    ohai "Copying binaries..."
+    cp_r %w[arm-none-eabi bin lib share], "#{prefix}/"
+  end
+end

--- a/Formula/gcc-arm-none-eabi-53.rb
+++ b/Formula/gcc-arm-none-eabi-53.rb
@@ -6,7 +6,7 @@ class GccArmNoneEabi53 < Formula
   url "https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/gcc-arm-none-eabi-5_3-2016q1-20160330-mac.tar.bz2"
   version "20160330"
   # url 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/5_3-2016q1/gccarmnoneeabi532016q120160330mactar.bz2?revision=f8c9bfa2-ae89-470c-a845-5fa423439b47?product=GNU-RM%20Downloads,64-bit,,Mac%20OS%20X,5-2016-q1-update'
-  sha256 "5656cdec40f99d5c054a85bbc694276e1c4a1488cdacbbc448bc6acd3bbe070d"
+  sha256 "480843ca1ce2d3602307f760872580e999acea0e34ec3d6f8b6ad02d3db409cf"
 
   def install
     ohai "Copying binaries..."


### PR DESCRIPTION
Fixes #11 

Changes:
- Initial version of formula for gcc-arm-none-eabi@5.3

Needs to be mentioned in CHANGELOG
yes