### PR TITLE
Update for CX v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Updates 2019/04
+
+### Added
+- Update CX formula for release [v0.6.2](https://github.com/skycoin/cx/releases/tag/v0.6.2)
+
+### Fixed
+
+### Changed
+
+### Removed
+
+## Updates Pre: 2019/04
 
 ### Added
 

--- a/Formula/skycoin-cx.rb
+++ b/Formula/skycoin-cx.rb
@@ -23,9 +23,9 @@
 class SkycoinCx < Formula
   desc "Skycoin CX is a general programming language based on affordances"
   homepage "https://github.com/skycoin/cx"
-  url "https://github.com/skycoin/cx/releases/download/v0.6.0/cx-0.6.0-bin-macos-x64.zip"
-  version "0.6.0"
-  sha256 "7834ef88116e41e376061eb9fe6c64640dbe8c8ec34522482ef786b9a1eaebb4"
+  url "https://github.com/skycoin/cx/releases/download/v0.6.2/cx-0.6.2-bin-macos-x64.zip"
+  version "0.6.2"
+  sha256 "92c6badd27c675bd4b4c7a2db68a22cdf4b0ea3dfa12ea75c7322e3c47420b25"
 
   bottle :unneeded
 


### PR DESCRIPTION
Fixes #18 

Changes:
- Update skycoin-cx.rb formula to reference [CX v0.6.2](https://github.com/skycoin/cx/releases/tag/v0.6.2)

Does this change need to mentioned in CHANGELOG.md?

Yes

