### PR TITLE
Update for skycoin-cli release v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Updates 2019/06
+
+### Added
+- Update Skycoin-cli formula for release [v0.26.0](https://github.com/skycoin/skycoin/releases/tag/v0.26.0)
+
+### Fixed
+
+### Changed
+
+### Removed
+
 ## Updates 2019/04
 
 ### Added

--- a/Formula/skycoin-cli.rb
+++ b/Formula/skycoin-cli.rb
@@ -23,9 +23,9 @@
 class SkycoinCli < Formula
   desc "Skycoin Command Line Interface (CLI)"
   homepage "https://github.com/skycoin/skycoin/tree/master/cmd/cli"
-  url "https://downloads.skycoin.net/wallet/skycoin-0.25.1-cli-osx-darwin-x64.zip"
-  version "0.25.1"
-  sha256 "449d8fc4527feb4f61e5013791b7098df702c2284a119f79ecda94042fc366c0"
+  url "https://downloads.skycoin.net/wallet/skycoin-0.26.0-cli-osx-darwin-x64.zip"
+  version "0.26.0"
+  sha256 "7e9932d9b8b6672be7d045f43930fca5e4103055f58fff519c0bcea7b5dfed47"
 
   bottle :unneeded
 


### PR DESCRIPTION
Fixes # NA

Changes:
- Updated `skycoin-cli` formula for v0.26.0 release

Does this change need to mentioned in CHANGELOG.md?
Yes. Included in the PR

